### PR TITLE
Ensure all mocks are reset and restored between tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,6 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  restoreMocks: true,
+  resetMocks: true,
 };

--- a/src/git-operations.test.ts
+++ b/src/git-operations.test.ts
@@ -41,10 +41,6 @@ describe('didPackageChange', () => {
     [TAGS.C]: `packages/${PACKAGES.B.dir}/file.txt\n`,
   };
 
-  afterEach(() => {
-    execaMock.mockClear();
-  });
-
   it('first call, failure: Throws if repo has invalid tags', async () => {
     execaMock.mockImplementationOnce(() => {
       return { stdout: 'foo\nbar\n' };

--- a/src/package-operations.test.ts
+++ b/src/package-operations.test.ts
@@ -56,16 +56,8 @@ const getMockManifest = (
 };
 
 describe('package-operations', () => {
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
-
   describe('getPackageManifest', () => {
     const readJsonFileMock = jest.spyOn(utils, 'readJsonFile');
-
-    afterAll(() => {
-      jest.resetAllMocks();
-    });
 
     it('gets and returns a valid manifest', async () => {
       const validManifest = { name: 'fooName', version: '1.0.0' };
@@ -128,7 +120,6 @@ describe('package-operations', () => {
   describe('getMetadataForAllPackages', () => {
     const readdirMock = jest.spyOn(fs.promises, 'readdir');
 
-    let mockIndex = -1;
     const names = ['name1', 'name2', 'name3'];
     const dirs = ['dir1', 'dir2', 'dir3'];
     const version = '1.0.0';
@@ -142,23 +133,22 @@ describe('package-operations', () => {
       };
     };
 
-    beforeAll(() => {
+    function getMockReadJsonFile() {
+      let mockIndex = -1;
+      return async () => {
+        mockIndex += 1;
+        return getMockManifest(names[mockIndex], version);
+      };
+    }
+
+    beforeEach(() => {
       jest.spyOn(fs.promises, 'lstat').mockImplementation((async () => {
         return { isDirectory: async () => true };
       }) as any);
 
-      jest.spyOn(utils, 'readJsonFile').mockImplementation(async () => {
-        mockIndex += 1;
-        return getMockManifest(names[mockIndex], version);
-      });
-    });
-
-    afterEach(() => {
-      mockIndex = -1;
-    });
-
-    afterAll(() => {
-      jest.restoreAllMocks();
+      jest
+        .spyOn(utils, 'readJsonFile')
+        .mockImplementation(getMockReadJsonFile());
     });
 
     it('placeholder', async () => {
@@ -184,14 +174,6 @@ describe('package-operations', () => {
       [packageNames[1]]: {},
       [packageNames[2]]: {},
     };
-
-    afterEach(() => {
-      jest.clearAllMocks();
-    });
-
-    afterAll(() => {
-      jest.restoreAllMocks();
-    });
 
     it('returns all packages if synchronizeVersions is true', async () => {
       expect(
@@ -241,10 +223,6 @@ describe('package-operations', () => {
 
     const mockDirs = ['dir1', 'dir2', 'dir3'];
     const packageNames = ['name1', 'name2', 'name3'];
-
-    afterAll(() => {
-      jest.restoreAllMocks();
-    });
 
     describe('updatePackage (singular)', () => {
       it('updates a package without dependencies', async () => {

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -94,10 +94,6 @@ describe('getActionInputs', () => {
 });
 
 describe('readJsonFile', () => {
-  afterAll(() => {
-    jest.clearAllMocks();
-  });
-
   it('reads a JSON file and returns it as an object', async () => {
     const expectedResult = { foo: ['bar', 'baz'] };
     const path = 'arbitrary/path';
@@ -136,10 +132,6 @@ describe('readJsonFile', () => {
 });
 
 describe('writeJsonFile', () => {
-  afterAll(() => {
-    jest.clearAllMocks();
-  });
-
   const stringify = (value: unknown) => `${JSON.stringify(value, null, 2)}\n`;
 
   it('stringifies a JSON-like value and writes it to disk', async () => {


### PR DESCRIPTION
The Jest options `resetMocks` and `restoreMocks` have been added to ensure all mocks are fully reset and restored between each test. This helps to prevent dependencies between tests, and makes some mistakes caused by misuse of shared mocks easier to spot (though it's not a perfect solution, and shared mocks should still be avoided if possible to further ensure complete test isolation).