### PR TITLE
Update Jest config, implement full test coverage

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -4321,8 +4321,8 @@ async function getMetadataForAllPackages(rootDir = WORKSPACE_ROOT, packagesDir =
     const result = {};
     await Promise.all(packagesDirContents.map(async (packageDir) => {
         const packagePath = external_path_default().join(packagesPath, packageDir);
-        const manifest = await getPackageManifest(packagePath);
         if ((await external_fs_.promises.lstat(packagePath)).isDirectory()) {
+            const manifest = await getPackageManifest(packagePath);
             result[manifest.name] = {
                 dirName: packageDir,
                 manifest,
@@ -4489,8 +4489,9 @@ function validatePackageManifest(manifest, manifestDirPath, requiredFields = ['n
         throw new Error(`Manifest in "${legiblePath}" does not have a valid "name" field.`);
     }
     if (requiredFields.includes('version') && !isValidSemver(manifest.version)) {
-        throw new Error(`${`"${manifest.name}" manifest "version"` ||
-            `"version" of manifest in "${legiblePath}"`} is not a valid SemVer version: ${manifest.version}`);
+        throw new Error(`${manifest.name
+            ? `"${manifest.name}" manifest "version"`
+            : `"version" of manifest in "${legiblePath}"`} is not a valid SemVer version: ${manifest.version}`);
     }
 }
 //# sourceMappingURL=package-operations.js.map

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,24 @@
 module.exports = {
+  collectCoverage: true,
+  coverageReporters: ['text', 'html'],
+  coverageThreshold: {
+    global: {
+      branches: 100,
+      functions: 100,
+      lines: 100,
+      statements: 100,
+    },
+  },
+  moduleFileExtensions: ['ts', 'js', 'json', 'node'],
   preset: 'ts-jest',
-  testEnvironment: 'node',
-  restoreMocks: true,
+  // "resetMocks" resets all mocks, including mocked modules, to jest.fn(),
+  // between each test case.
   resetMocks: true,
+  // "restoreMocks" restores all mocks created using jest.spyOn to their
+  // original implementations, between each test. It does not affect mocked
+  // modules.
+  restoreMocks: true,
+  testEnvironment: 'node',
+  testRegex: ['\\.test\\.(ts|js)$'],
+  testTimeout: 2500,
 };

--- a/src/package-operations.test.ts
+++ b/src/package-operations.test.ts
@@ -56,7 +56,11 @@ const getMockManifest = (
 
 describe('package-operations', () => {
   describe('getPackageManifest', () => {
-    const readJsonFileMock = jest.spyOn(utils, 'readJsonFile');
+    let readJsonFileMock: jest.SpyInstance;
+
+    beforeEach(() => {
+      readJsonFileMock = jest.spyOn(utils, 'readJsonFile');
+    });
 
     it('gets and returns a valid manifest', async () => {
       const validManifest = { name: 'fooName', version: '1.0.0' };
@@ -123,7 +127,7 @@ describe('package-operations', () => {
   });
 
   describe('getMetadataForAllPackages', () => {
-    const readdirMock = jest.spyOn(fs.promises, 'readdir');
+    let readdirMock: jest.SpyInstance;
 
     const names = ['name1', 'name2', 'name3'];
     const dirs = ['dir1', 'dir2', 'dir3'];
@@ -148,6 +152,8 @@ describe('package-operations', () => {
     }
 
     beforeEach(() => {
+      readdirMock = jest.spyOn(fs.promises, 'readdir');
+
       jest.spyOn(fs.promises, 'lstat').mockImplementation((async (
         path: string,
       ) => {
@@ -175,7 +181,7 @@ describe('package-operations', () => {
   });
 
   describe('getPackagesToUpdate', () => {
-    const didPackageChangeMock = jest.spyOn(gitOps, 'didPackageChange');
+    let didPackageChangeMock: jest.SpyInstance;
 
     const packageNames = ['name1', 'name2', 'name3'];
 
@@ -184,6 +190,10 @@ describe('package-operations', () => {
       [packageNames[1]]: {},
       [packageNames[2]]: {},
     };
+
+    beforeEach(() => {
+      didPackageChangeMock = jest.spyOn(gitOps, 'didPackageChange');
+    });
 
     it('returns all packages if synchronizeVersions is true', async () => {
       expect(

--- a/src/package-operations.ts
+++ b/src/package-operations.ts
@@ -59,9 +59,9 @@ export async function getMetadataForAllPackages(
   await Promise.all(
     packagesDirContents.map(async (packageDir) => {
       const packagePath = pathUtils.join(packagesPath, packageDir);
-      const manifest = await getPackageManifest(packagePath);
 
       if ((await fs.lstat(packagePath)).isDirectory()) {
+        const manifest = await getPackageManifest(packagePath);
         result[manifest.name] = {
           dirName: packageDir,
           manifest,
@@ -295,8 +295,9 @@ function validatePackageManifest(
   if (requiredFields.includes('version') && !isValidSemver(manifest.version)) {
     throw new Error(
       `${
-        `"${manifest.name}" manifest "version"` ||
-        `"version" of manifest in "${legiblePath}"`
+        manifest.name
+          ? `"${manifest.name}" manifest "version"`
+          : `"version" of manifest in "${legiblePath}"`
       } is not a valid SemVer version: ${manifest.version}`,
     );
   }


### PR DESCRIPTION
This PR updates our Jest config per our [module template](https://github.com/MetaMask/metamask-module-template) and achieves 100% test coverage. In maximizing the test coverage, a minor bug was found in `package-operations.ts`, which is also fixed.