### PR TITLE
Permit lack of git tags with complete git history

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -2,10 +2,6 @@ name: 'Create Monorepo Release PR'
 description: 'Update the versions of monorepo packages and create a release PR.'
 
 inputs:
-  initial-release:
-    default: 'false'
-    description: '"true" or "false". Whether the PR is for the initial release of the package.'
-    required: false
   release-type:
     description: 'A SemVer version diff, e.g. "major", "minor", or "patch". Mutually exclusive with "release-version".'
     required: false
@@ -20,7 +16,6 @@ runs:
       shell: bash
       run: node ${{ github.action_path }}/dist/index.js
       env:
-        IS_INITIAL_RELEASE: ${{ inputs.initial-release }}
         RELEASE_TYPE: ${{ inputs.release-type }}
         RELEASE_VERSION: ${{ inputs.release-version }}
     - id: create-release-pr

--- a/action.yml
+++ b/action.yml
@@ -2,11 +2,15 @@ name: 'Create Monorepo Release PR'
 description: 'Update the versions of monorepo packages and create a release PR.'
 
 inputs:
+  initial-release:
+    default: 'false'
+    description: '"true" or "false". Whether the PR is for the initial release of the package.'
+    required: false
   release-type:
-    description: 'A SemVer version diff, i.e. major, minor, patch, prerelease etc. Mutually exclusive with "release-version".'
+    description: 'A SemVer version diff, e.g. "major", "minor", or "patch". Mutually exclusive with "release-version".'
     required: false
   release-version:
-    description: 'A specific version to bump to. Mutually exclusive with "release-type".'
+    description: 'A plain SemVer version string, specifying the version to bump to. Mutually exclusive with "release-type".'
     required: false
 
 runs:
@@ -16,6 +20,7 @@ runs:
       shell: bash
       run: node ${{ github.action_path }}/dist/index.js
       env:
+        INITIAL_RELEASE: ${{ inputs.initial-release }}
         RELEASE_TYPE: ${{ inputs.release-type }}
         RELEASE_VERSION: ${{ inputs.release-version }}
     - id: create-release-pr

--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ runs:
       shell: bash
       run: node ${{ github.action_path }}/dist/index.js
       env:
-        INITIAL_RELEASE: ${{ inputs.initial-release }}
+        IS_INITIAL_RELEASE: ${{ inputs.initial-release }}
         RELEASE_TYPE: ${{ inputs.release-type }}
         RELEASE_VERSION: ${{ inputs.release-version }}
     - id: create-release-pr

--- a/dist/index.js
+++ b/dist/index.js
@@ -4045,7 +4045,7 @@ var parse_default = /*#__PURE__*/__nccwpck_require__.n(parse);
 // Our custom input env keys
 var InputKeys;
 (function (InputKeys) {
-    InputKeys["InitialRelease"] = "INITIAL_RELEASE";
+    InputKeys["IsInitialRelease"] = "IS_INITIAL_RELEASE";
     InputKeys["ReleaseType"] = "RELEASE_TYPE";
     InputKeys["ReleaseVersion"] = "RELEASE_VERSION";
 })(InputKeys || (InputKeys = {}));
@@ -4063,7 +4063,7 @@ var AcceptedSemverReleaseTypes;
  */
 var InputNames;
 (function (InputNames) {
-    InputNames["InitialRelease"] = "initial-release";
+    InputNames["IsInitialRelease"] = "initial-release";
     InputNames["ReleaseType"] = "release-type";
     InputNames["ReleaseVersion"] = "release-version";
 })(InputNames || (InputNames = {}));
@@ -4078,7 +4078,7 @@ const TWO_SPACES = '  ';
  */
 function getActionInputs() {
     const inputs = {
-        InitialRelease: process.env[InputKeys.InitialRelease] === 'true',
+        IsInitialRelease: process.env[InputKeys.IsInitialRelease] === 'true',
         ReleaseType: process.env[InputKeys.ReleaseType] ||
             null,
         ReleaseVersion: process.env[InputKeys.ReleaseVersion] || null,
@@ -4091,9 +4091,9 @@ function getActionInputs() {
  * Throws an error if validation fails.
  */
 function validateActionInputs(inputs) {
-    if (process.env.INITIAL_RELEASE !== 'true' &&
-        process.env.INITIAL_RELEASE !== 'false') {
-        throw new Error(`"${InputNames.InitialRelease}" must be either "true" or "false".`);
+    if (process.env.IS_INITIAL_RELEASE !== 'true' &&
+        process.env.IS_INITIAL_RELEASE !== 'false') {
+        throw new Error(`"${InputNames.IsInitialRelease}" must be either "true" or "false".`);
     }
     if (!inputs.ReleaseType && !inputs.ReleaseVersion) {
         throw new Error(`Must specify either "${InputNames.ReleaseType}" or "${InputNames.ReleaseVersion}".`);
@@ -4529,8 +4529,8 @@ main().catch((error) => {
 async function main() {
     const actionInputs = getActionInputs();
     // Get all git tags. If "git tag" returns no tags, an error is thrown unless
-    // the InitialRelease input is true.
-    await initializeGit(actionInputs.InitialRelease);
+    // the IsInitialRelease input is true.
+    await initializeGit(actionInputs.IsInitialRelease);
     const rootManifest = await getPackageManifest(WORKSPACE_ROOT, ['version']);
     const { version: currentVersion } = rootManifest;
     // Compute the new version and version diff from the inputs and root manifest

--- a/dist/index.js
+++ b/dist/index.js
@@ -4201,6 +4201,8 @@ let INITIALIZED_GIT = false;
 let TAGS;
 const DIFFS = new Map();
 /**
+ * ATTN: This function must be called before other git operations are performed.
+ *
  * Executes "git tag" and caches the result.
  * Idempotent, but only if executed serially.
  *
@@ -4269,7 +4271,8 @@ async function performDiff(tag, packagesDir) {
     return (await performGitOperation('diff', tag, HEAD, '--name-only', '--', packagesDir)).split('\n');
 }
 /**
- * Only exported for testing purposes. Consumers should use initializeGit.
+ * ATTN: Only exported for testing purposes. Consumers should use initializeGit.
+ *
  * Utility function for executing "git tag" and parsing the result.
  *
  * @param allowNoTags - Whether to permit "git tag" returning no tags.

--- a/dist/index.js
+++ b/dist/index.js
@@ -4045,6 +4045,7 @@ var parse_default = /*#__PURE__*/__nccwpck_require__.n(parse);
 // Our custom input env keys
 var InputKeys;
 (function (InputKeys) {
+    InputKeys["InitialRelease"] = "INITIAL_RELEASE";
     InputKeys["ReleaseType"] = "RELEASE_TYPE";
     InputKeys["ReleaseVersion"] = "RELEASE_VERSION";
 })(InputKeys || (InputKeys = {}));
@@ -4062,6 +4063,7 @@ var AcceptedSemverReleaseTypes;
  */
 var InputNames;
 (function (InputNames) {
+    InputNames["InitialRelease"] = "initial-release";
     InputNames["ReleaseType"] = "release-type";
     InputNames["ReleaseVersion"] = "release-version";
 })(InputNames || (InputNames = {}));
@@ -4076,8 +4078,10 @@ const TWO_SPACES = '  ';
  */
 function getActionInputs() {
     const inputs = {
-        ReleaseType: process.env.RELEASE_TYPE || null,
-        ReleaseVersion: process.env.RELEASE_VERSION || null,
+        InitialRelease: process.env[InputKeys.InitialRelease] === 'true',
+        ReleaseType: process.env[InputKeys.ReleaseType] ||
+            null,
+        ReleaseVersion: process.env[InputKeys.ReleaseVersion] || null,
     };
     validateActionInputs(inputs);
     return inputs;
@@ -4087,6 +4091,10 @@ function getActionInputs() {
  * Throws an error if validation fails.
  */
 function validateActionInputs(inputs) {
+    if (process.env.INITIAL_RELEASE !== 'true' &&
+        process.env.INITIAL_RELEASE !== 'false') {
+        throw new Error(`"${InputNames.InitialRelease}" must be either "true" or "false".`);
+    }
     if (!inputs.ReleaseType && !inputs.ReleaseVersion) {
         throw new Error(`Must specify either "${InputNames.ReleaseType}" or "${InputNames.ReleaseVersion}".`);
     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -4283,6 +4283,8 @@ async function performDiff(tag, packagesDir) {
  * The tuple is populated by an empty array and null if there are no tags.
  */
 async function getTags() {
+    // The --merged flag ensures that we only get tags that are parents of or
+    // equal to the current HEAD.
     const rawTags = await performGitOperation('tag', '--merged');
     const allTags = rawTags.split('\n').filter((value) => value !== '');
     if (allTags.length === 0) {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "yarn": ">=1.22.0 <2.0.0"
   },
   "scripts": {
-    "lint:eslint": "yarn eslint . --ext js,ts",
+    "lint:eslint": "yarn eslint . --cache --ext js,ts",
     "lint:misc": "prettier '**/*.json' '**/*.md' '**/*.yml' --single-quote --ignore-path .gitignore",
     "lint": "yarn lint:eslint && yarn lint:misc --check",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",

--- a/src/git-operations.test.ts
+++ b/src/git-operations.test.ts
@@ -1,67 +1,61 @@
 import execa from 'execa';
-import { didPackageChange } from './git-operations';
+import { didPackageChange, initializeGit, getTags } from './git-operations';
 
 // We don't actually use it, so it doesn't matter what it is.
 process.env.GITHUB_WORKSPACE = 'root';
 
 jest.mock('execa');
+const execaMock: jest.Mock<any, any> = execa as any;
+
+enum VERSIONS {
+  A = '1.0.0',
+  B = '1.0.1',
+  C = '1.1.0',
+}
+
+enum TAGS {
+  A = 'v1.0.0',
+  B = 'v1.0.1',
+  C = 'v1.1.0',
+}
+
+const PACKAGES: Readonly<Record<string, { name: string; dir: string }>> = {
+  A: { name: 'fooName', dir: 'foo' },
+  B: { name: 'barName', dir: 'bar' },
+};
+
+const RAW_MOCK_TAGS = `${Object.values(TAGS).join('\n')}\n`;
+
+const RAW_DIFFS: Readonly<Record<TAGS, string>> = {
+  [TAGS.A]: `packages/${PACKAGES.A.dir}/file.txt\npackages/${PACKAGES.B.dir}/file.txt\n`,
+  [TAGS.B]: `packages/${PACKAGES.A.dir}/file.txt\n`,
+  [TAGS.C]: `packages/${PACKAGES.B.dir}/file.txt\n`,
+};
 
 /**
- * ATTN: These cases are order-dependent.
- *
- * The first call to didPackageChange performs some initialization work.
- * Calls for valid tags, computed from packageData.manifest.version, are cached,
- * and future calls for the same tag perform no git operations.
+ * ATTN: This test suite is order-dependent due to git tag results being cached
+ * in the git-operations module.
+ * The "initializeGit" tests must run before the "didPackageChange" tests.
  */
-describe('didPackageChange', () => {
-  const execaMock: ReturnType<typeof jest.fn> = execa as any;
 
-  const VERSIONS = {
-    A: '1.0.0',
-    B: '1.0.1',
-    C: '1.1.0',
-  };
-
-  const TAGS = {
-    A: 'v1.0.0',
-    B: 'v1.0.1',
-    C: 'v1.1.0',
-  };
-
-  const PACKAGES = {
-    A: { name: 'fooName', dir: 'foo' },
-    B: { name: 'barName', dir: 'bar' },
-  };
-
-  const RAW_MOCK_TAGS = `${Object.values(TAGS).join('\n')}\n`;
-
-  const RAW_DIFFS = {
-    [TAGS.A]: `packages/${PACKAGES.A.dir}/file.txt\npackages/${PACKAGES.B.dir}/file.txt\n`,
-    [TAGS.B]: `packages/${PACKAGES.A.dir}/file.txt\n`,
-    [TAGS.C]: `packages/${PACKAGES.B.dir}/file.txt\n`,
-  };
-
-  it('first call, failure: Throws if repo has invalid tags', async () => {
-    execaMock.mockImplementationOnce(() => {
-      return { stdout: 'foo\nbar\n' };
+describe('initializeGit', () => {
+  it('fetches the git tags', async () => {
+    execaMock.mockImplementationOnce(async () => {
+      return { stdout: RAW_MOCK_TAGS };
     });
-
-    await expect(
-      didPackageChange({
-        name: PACKAGES.A.name,
-        manifest: { name: PACKAGES.A.name, version: VERSIONS.A },
-        dirName: PACKAGES.A.dir,
-        dirPath: '', // just for interface compliance, not relevant
-      }),
-    ).rejects.toThrow(/^Invalid latest tag/u);
+    expect(await initializeGit(false)).toBeUndefined();
     expect(execaMock).toHaveBeenCalledTimes(1);
   });
 
-  it('first call, success: Calls "git tag" and "git diff" with expected tag', async () => {
-    execaMock.mockImplementationOnce(() => {
-      return { stdout: RAW_MOCK_TAGS };
-    });
-    execaMock.mockImplementationOnce(() => {
+  it('is idempotent', async () => {
+    expect(await initializeGit(false)).toBeUndefined();
+    expect(execaMock).toHaveBeenCalledTimes(0);
+  });
+});
+
+describe('didPackageChange', () => {
+  it('calls "git tag" and "git diff" with expected tag', async () => {
+    execaMock.mockImplementationOnce(async () => {
       return { stdout: RAW_DIFFS[TAGS.A] };
     });
 
@@ -73,7 +67,7 @@ describe('didPackageChange', () => {
         dirPath: '', // just for interface compliance, not relevant
       }),
     ).toStrictEqual(true);
-    expect(execaMock).toHaveBeenCalledTimes(2);
+    expect(execaMock).not.toHaveBeenCalledTimes(2);
   });
 
   it('repeat call for tag retrieves result from cache', async () => {
@@ -110,5 +104,36 @@ describe('didPackageChange', () => {
       }),
     ).rejects.toThrow(/no corresponding tag/u);
     expect(execaMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('getTags', () => {
+  it('succeeds if repo has no tags and allowNoTags is true', async () => {
+    execaMock.mockImplementationOnce(async () => {
+      return { stdout: '' };
+    });
+
+    expect(await getTags(true)).toStrictEqual([[], null]);
+    expect(execaMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws if repo has no tags and allowNoTags is false', async () => {
+    execaMock.mockImplementationOnce(async () => {
+      return { stdout: '' };
+    });
+
+    await expect(getTags(false)).rejects.toThrow(
+      /^"git tag" returned no tags/u,
+    );
+    expect(execaMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws if repo has invalid tags', async () => {
+    execaMock.mockImplementationOnce(async () => {
+      return { stdout: 'foo\nbar\n' };
+    });
+
+    await expect(getTags(false)).rejects.toThrow(/^Invalid latest tag/u);
+    expect(execaMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/git-operations.test.ts
+++ b/src/git-operations.test.ts
@@ -54,7 +54,7 @@ describe('initializeGit', () => {
 });
 
 describe('didPackageChange', () => {
-  it('calls "git tag" and "git diff" with expected tag', async () => {
+  it('calls "git diff" with expected tag', async () => {
     execaMock.mockImplementationOnce(async () => {
       return { stdout: RAW_DIFFS[TAGS.A] };
     });
@@ -67,7 +67,7 @@ describe('didPackageChange', () => {
         dirPath: '', // just for interface compliance, not relevant
       }),
     ).toStrictEqual(true);
-    expect(execaMock).not.toHaveBeenCalledTimes(2);
+    expect(execaMock).toHaveBeenCalledTimes(1);
   });
 
   it('repeat call for tag retrieves result from cache', async () => {

--- a/src/git-operations.ts
+++ b/src/git-operations.ts
@@ -9,20 +9,20 @@ const HEAD = 'HEAD';
 type DiffMap = Map<string, string[]>;
 
 let INITIALIZED_GIT = false;
-let TAGS: Readonly<string[]>;
+let TAGS: Readonly<Set<string>>;
 const DIFFS: DiffMap = new Map();
 
 /**
  * ATTN: This function must be called before other git operations are performed.
  *
- * Executes "git tag" and caches the result.
- * Idempotent, but only if executed serially.
+ * Executes "git tag" and caches the result. Throws an error if fetching tags
+ * fails.
  *
- * @param allowNoTags - Whether to permit "git tag" returning no tags.
+ * Idempotent, but only if executed serially.
  */
-export async function initializeGit(allowNoTags: boolean): Promise<void> {
+export async function initializeGit(): Promise<void> {
   if (!INITIALIZED_GIT) {
-    [TAGS] = await getTags(allowNoTags);
+    [TAGS] = await getTags();
     // eslint-disable-next-line require-atomic-updates
     INITIALIZED_GIT = true;
   }
@@ -33,31 +33,41 @@ export async function initializeGit(allowNoTags: boolean): Promise<void> {
  *
  * Using git, checks whether the package changed since it was last released.
  *
- * Assumes that:
- * - initializeGit has been called.
+ * Assumes that initializeGit has been called. If it's not the
+ * first release of the package, also assumes that:
+ *
  * - The "version" field of the package's manifest corresponds to its latest
  * released version.
- * - The release commit of the package's latest version is tagged with
+ * - The release commit of the package's most recent version is tagged with
  * "v<VERSION>", where <VERSION> is equal to the manifest's "version" field.
  *
  * @param packageData - The metadata of the package to diff.
- * @returns Whether the package changed since its last release.
+ * @param packagesDir - The directory containing the monorepo's packages.
+ * @returns Whether the package changed since its last release. `true` is
+ * returned if there are no releases in the repository's history.
  */
 export async function didPackageChange(
   packageData: PackageMetadata,
   packagesDir = 'packages',
+  _tags: never = TAGS as never, // for testing purposes
 ): Promise<boolean> {
+  const tags = _tags as typeof TAGS;
+  // In this case, we assume that it's the first release, and every package
+  // is implicitly considered to have "changed".
+  if (tags.size === 0) {
+    return true;
+  }
+
   const {
     manifest: { name: packageName, version: currentVersion },
   } = packageData;
   const tagOfCurrentVersion = versionToTag(currentVersion);
 
-  if (!TAGS.includes(tagOfCurrentVersion)) {
+  if (!tags.has(tagOfCurrentVersion)) {
     throw new Error(
       `Package "${packageName}" has version "${currentVersion}" in its manifest, but no corresponding tag "${tagOfCurrentVersion}" exists.`,
     );
   }
-
   return hasDiff(packageData, tagOfCurrentVersion, packagesDir);
 }
 
@@ -116,21 +126,23 @@ async function performDiff(
  * ATTN: Only exported for testing purposes. Consumers should use initializeGit.
  *
  * Utility function for executing "git tag" and parsing the result.
+ * An error is thrown if no tags are found and the local git history is
+ * incomplete.
  *
- * @param allowNoTags - Whether to permit "git tag" returning no tags.
  * @returns A tuple of all tags as a string array and the latest tag.
+ * The tuple is populated by an empty array and null if there are no tags.
  */
-export async function getTags(
-  allowNoTags: boolean,
-): Promise<Readonly<[string[], string | null]>> {
-  const rawTags = await performGitOperation('tag');
+export async function getTags(): Promise<
+  Readonly<[Set<string>, string | null]>
+> {
+  const rawTags = await performGitOperation('tag', '--merged');
   const allTags = rawTags.split('\n').filter((value) => value !== '');
   if (allTags.length === 0) {
-    if (allowNoTags) {
-      return [[], null];
+    if (await hasCompleteGitHistory()) {
+      return [new Set(), null];
     }
     throw new Error(
-      `"git tag" returned no tags. Ensure that you've fetched the complete git history.`,
+      `"git tag" returned no tags. Increase your git fetch depth.`,
     );
   }
 
@@ -140,7 +152,32 @@ export async function getTags(
       `Invalid latest tag. Expected a valid SemVer version. Received: ${latestTag}`,
     );
   }
-  return [allTags, latestTag] as const;
+  return [new Set(allTags), latestTag] as const;
+}
+
+/**
+ * Check whether the local repository has a complete git history.
+ * Implemented using "git rev-parse --is-shallow-repository".
+ *
+ * @returns Whether the local repository has a complete, as opposed to shallow,
+ * git history.
+ */
+async function hasCompleteGitHistory(): Promise<boolean> {
+  const isShallow = await performGitOperation(
+    'rev-parse',
+    '--is-shallow-repository',
+  );
+
+  // We invert the meaning of these strings because we want to know if the
+  // repository is NOT shallow.
+  if (isShallow === 'true') {
+    return false;
+  } else if (isShallow === 'false') {
+    return true;
+  }
+  throw new Error(
+    `"git rev-parse --is-shallow-repository" returned unrecognized value: ${isShallow}`,
+  );
 }
 
 /**

--- a/src/git-operations.ts
+++ b/src/git-operations.ts
@@ -135,8 +135,11 @@ async function performDiff(
 export async function getTags(): Promise<
   Readonly<[Set<string>, string | null]>
 > {
+  // The --merged flag ensures that we only get tags that are parents of or
+  // equal to the current HEAD.
   const rawTags = await performGitOperation('tag', '--merged');
   const allTags = rawTags.split('\n').filter((value) => value !== '');
+
   if (allTags.length === 0) {
     if (await hasCompleteGitHistory()) {
       return [new Set(), null];

--- a/src/git-operations.ts
+++ b/src/git-operations.ts
@@ -13,6 +13,8 @@ let TAGS: Readonly<string[]>;
 const DIFFS: DiffMap = new Map();
 
 /**
+ * ATTN: This function must be called before other git operations are performed.
+ *
  * Executes "git tag" and caches the result.
  * Idempotent, but only if executed serially.
  *
@@ -111,7 +113,8 @@ async function performDiff(
 }
 
 /**
- * Only exported for testing purposes. Consumers should use initializeGit.
+ * ATTN: Only exported for testing purposes. Consumers should use initializeGit.
+ *
  * Utility function for executing "git tag" and parsing the result.
  *
  * @param allowNoTags - Whether to permit "git tag" returning no tags.

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,8 +24,8 @@ async function main(): Promise<void> {
   const actionInputs = getActionInputs();
 
   // Get all git tags. If "git tag" returns no tags, an error is thrown unless
-  // the InitialRelease input is true.
-  await initializeGit(actionInputs.InitialRelease);
+  // the IsInitialRelease input is true.
+  await initializeGit(actionInputs.IsInitialRelease);
 
   const rootManifest = await getPackageManifest(WORKSPACE_ROOT, ['version']);
   const { version: currentVersion } = rootManifest;

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,9 +23,9 @@ main().catch((error) => {
 async function main(): Promise<void> {
   const actionInputs = getActionInputs();
 
-  // Get all git tags. If "git tag" returns no tags, an error is thrown unless
-  // the IsInitialRelease input is true.
-  await initializeGit(actionInputs.IsInitialRelease);
+  // Get all git tags. An error is thrown if "git tag" returns no tags and the
+  // local git history is incomplete.
+  await initializeGit();
 
   const rootManifest = await getPackageManifest(WORKSPACE_ROOT, ['version']);
   const { version: currentVersion } = rootManifest;

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import {
   getPackageManifest,
   updatePackage,
 } from './package-operations';
+import { initializeGit } from './git-operations';
 import { getActionInputs, isMajorSemverDiff, WORKSPACE_ROOT } from './utils';
 
 main().catch((error) => {
@@ -21,6 +22,10 @@ main().catch((error) => {
 
 async function main(): Promise<void> {
   const actionInputs = getActionInputs();
+
+  // Get all git tags. If "git tag" returns no tags, an error is thrown unless
+  // the InitialRelease input is true.
+  await initializeGit(actionInputs.InitialRelease);
 
   const rootManifest = await getPackageManifest(WORKSPACE_ROOT, ['version']);
   const { version: currentVersion } = rootManifest;

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -19,17 +19,12 @@ jest.mock('fs', () => ({
 }));
 
 const mockProcessEnv = ({
-  isInitialRelease = 'false',
   releaseType,
   releaseVersion,
 }: {
-  isInitialRelease?: string;
   releaseType?: string;
   releaseVersion?: string;
 }) => {
-  if (isInitialRelease !== undefined) {
-    process.env[InputKeys.IsInitialRelease] = isInitialRelease;
-  }
   if (releaseType !== undefined) {
     process.env[InputKeys.ReleaseType] = releaseType;
   }
@@ -47,21 +42,10 @@ describe('getActionInputs', () => {
     unmockProcessEnv();
   });
 
-  it('correctly parses valid input: initial-release = "true"', () => {
-    const releaseVersion = '1.0.0';
-    mockProcessEnv({ releaseVersion, isInitialRelease: 'true' });
-    expect(getActionInputs()).toStrictEqual({
-      IsInitialRelease: true,
-      ReleaseType: null,
-      ReleaseVersion: releaseVersion,
-    });
-  });
-
   it('correctly parses valid input: release-type', () => {
     for (const releaseType of Object.values(AcceptedSemverReleaseTypes)) {
       mockProcessEnv({ releaseType });
       expect(getActionInputs()).toStrictEqual({
-        IsInitialRelease: false,
         ReleaseType: releaseType,
         ReleaseVersion: null,
       });
@@ -73,18 +57,10 @@ describe('getActionInputs', () => {
     for (const releaseVersion of versions) {
       mockProcessEnv({ releaseVersion });
       expect(getActionInputs()).toStrictEqual({
-        IsInitialRelease: false,
         ReleaseType: null,
         ReleaseVersion: releaseVersion,
       });
     }
-  });
-
-  it('throws if "initial-release" is an invalid value', () => {
-    mockProcessEnv({ isInitialRelease: 'foo' });
-    expect(() => getActionInputs()).toThrow(
-      /must be either "true" or "false"/u,
-    );
   });
 
   it('throws if neither "release-type" nor "release-version" are specified', () => {

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -19,16 +19,16 @@ jest.mock('fs', () => ({
 }));
 
 const mockProcessEnv = ({
-  initialRelease = 'false',
+  isInitialRelease = 'false',
   releaseType,
   releaseVersion,
 }: {
-  initialRelease?: string;
+  isInitialRelease?: string;
   releaseType?: string;
   releaseVersion?: string;
 }) => {
-  if (initialRelease !== undefined) {
-    process.env[InputKeys.InitialRelease] = initialRelease;
+  if (isInitialRelease !== undefined) {
+    process.env[InputKeys.IsInitialRelease] = isInitialRelease;
   }
   if (releaseType !== undefined) {
     process.env[InputKeys.ReleaseType] = releaseType;
@@ -49,9 +49,9 @@ describe('getActionInputs', () => {
 
   it('correctly parses valid input: initial-release = "true"', () => {
     const releaseVersion = '1.0.0';
-    mockProcessEnv({ releaseVersion, initialRelease: 'true' });
+    mockProcessEnv({ releaseVersion, isInitialRelease: 'true' });
     expect(getActionInputs()).toStrictEqual({
-      InitialRelease: true,
+      IsInitialRelease: true,
       ReleaseType: null,
       ReleaseVersion: releaseVersion,
     });
@@ -61,7 +61,7 @@ describe('getActionInputs', () => {
     for (const releaseType of Object.values(AcceptedSemverReleaseTypes)) {
       mockProcessEnv({ releaseType });
       expect(getActionInputs()).toStrictEqual({
-        InitialRelease: false,
+        IsInitialRelease: false,
         ReleaseType: releaseType,
         ReleaseVersion: null,
       });
@@ -73,7 +73,7 @@ describe('getActionInputs', () => {
     for (const releaseVersion of versions) {
       mockProcessEnv({ releaseVersion });
       expect(getActionInputs()).toStrictEqual({
-        InitialRelease: false,
+        IsInitialRelease: false,
         ReleaseType: null,
         ReleaseVersion: releaseVersion,
       });
@@ -81,7 +81,7 @@ describe('getActionInputs', () => {
   });
 
   it('throws if "initial-release" is an invalid value', () => {
-    mockProcessEnv({ initialRelease: 'foo' });
+    mockProcessEnv({ isInitialRelease: 'foo' });
     expect(() => getActionInputs()).toThrow(
       /must be either "true" or "false"/u,
     );

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,7 +4,7 @@ import type { ReleaseType as SemverReleaseType } from 'semver';
 
 // Our custom input env keys
 export enum InputKeys {
-  InitialRelease = 'INITIAL_RELEASE',
+  IsInitialRelease = 'IS_INITIAL_RELEASE',
   ReleaseType = 'RELEASE_TYPE',
   ReleaseVersion = 'RELEASE_VERSION',
 }
@@ -27,7 +27,7 @@ declare global {
     interface ProcessEnv {
       // The root of the workspace running this action
       GITHUB_WORKSPACE: string;
-      [InputKeys.InitialRelease]: string;
+      [InputKeys.IsInitialRelease]: string;
       [InputKeys.ReleaseType]: string;
       [InputKeys.ReleaseVersion]: string;
     }
@@ -38,13 +38,13 @@ declare global {
  * The names of the inputs to the Action, per action.yml.
  */
 export enum InputNames {
-  InitialRelease = 'initial-release',
+  IsInitialRelease = 'initial-release',
   ReleaseType = 'release-type',
   ReleaseVersion = 'release-version',
 }
 
 export interface ActionInputs {
-  readonly InitialRelease: boolean;
+  readonly IsInitialRelease: boolean;
   readonly ReleaseType: AcceptedSemverReleaseTypes | null;
   readonly ReleaseVersion: string | null;
 }
@@ -62,7 +62,7 @@ const TWO_SPACES = '  ';
  */
 export function getActionInputs(): ActionInputs {
   const inputs: ActionInputs = {
-    InitialRelease: process.env[InputKeys.InitialRelease] === 'true',
+    IsInitialRelease: process.env[InputKeys.IsInitialRelease] === 'true',
     ReleaseType:
       (process.env[InputKeys.ReleaseType] as AcceptedSemverReleaseTypes) ||
       null,
@@ -78,11 +78,11 @@ export function getActionInputs(): ActionInputs {
  */
 function validateActionInputs(inputs: ActionInputs): void {
   if (
-    process.env.INITIAL_RELEASE !== 'true' &&
-    process.env.INITIAL_RELEASE !== 'false'
+    process.env.IS_INITIAL_RELEASE !== 'true' &&
+    process.env.IS_INITIAL_RELEASE !== 'false'
   ) {
     throw new Error(
-      `"${InputNames.InitialRelease}" must be either "true" or "false".`,
+      `"${InputNames.IsInitialRelease}" must be either "true" or "false".`,
     );
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,6 +4,7 @@ import type { ReleaseType as SemverReleaseType } from 'semver';
 
 // Our custom input env keys
 export enum InputKeys {
+  InitialRelease = 'INITIAL_RELEASE',
   ReleaseType = 'RELEASE_TYPE',
   ReleaseVersion = 'RELEASE_VERSION',
 }
@@ -26,6 +27,7 @@ declare global {
     interface ProcessEnv {
       // The root of the workspace running this action
       GITHUB_WORKSPACE: string;
+      [InputKeys.InitialRelease]: string;
       [InputKeys.ReleaseType]: string;
       [InputKeys.ReleaseVersion]: string;
     }
@@ -36,11 +38,13 @@ declare global {
  * The names of the inputs to the Action, per action.yml.
  */
 export enum InputNames {
+  InitialRelease = 'initial-release',
   ReleaseType = 'release-type',
   ReleaseVersion = 'release-version',
 }
 
 export interface ActionInputs {
+  readonly InitialRelease: boolean;
   readonly ReleaseType: AcceptedSemverReleaseTypes | null;
   readonly ReleaseVersion: string | null;
 }
@@ -58,9 +62,11 @@ const TWO_SPACES = '  ';
  */
 export function getActionInputs(): ActionInputs {
   const inputs: ActionInputs = {
+    InitialRelease: process.env[InputKeys.InitialRelease] === 'true',
     ReleaseType:
-      (process.env.RELEASE_TYPE as AcceptedSemverReleaseTypes) || null,
-    ReleaseVersion: process.env.RELEASE_VERSION || null,
+      (process.env[InputKeys.ReleaseType] as AcceptedSemverReleaseTypes) ||
+      null,
+    ReleaseVersion: process.env[InputKeys.ReleaseVersion] || null,
   };
   validateActionInputs(inputs);
   return inputs;
@@ -71,6 +77,15 @@ export function getActionInputs(): ActionInputs {
  * Throws an error if validation fails.
  */
 function validateActionInputs(inputs: ActionInputs): void {
+  if (
+    process.env.INITIAL_RELEASE !== 'true' &&
+    process.env.INITIAL_RELEASE !== 'false'
+  ) {
+    throw new Error(
+      `"${InputNames.InitialRelease}" must be either "true" or "false".`,
+    );
+  }
+
   if (!inputs.ReleaseType && !inputs.ReleaseVersion) {
     throw new Error(
       `Must specify either "${InputNames.ReleaseType}" or "${InputNames.ReleaseVersion}".`,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,7 +4,6 @@ import type { ReleaseType as SemverReleaseType } from 'semver';
 
 // Our custom input env keys
 export enum InputKeys {
-  IsInitialRelease = 'IS_INITIAL_RELEASE',
   ReleaseType = 'RELEASE_TYPE',
   ReleaseVersion = 'RELEASE_VERSION',
 }
@@ -27,7 +26,6 @@ declare global {
     interface ProcessEnv {
       // The root of the workspace running this action
       GITHUB_WORKSPACE: string;
-      [InputKeys.IsInitialRelease]: string;
       [InputKeys.ReleaseType]: string;
       [InputKeys.ReleaseVersion]: string;
     }
@@ -38,13 +36,11 @@ declare global {
  * The names of the inputs to the Action, per action.yml.
  */
 export enum InputNames {
-  IsInitialRelease = 'initial-release',
   ReleaseType = 'release-type',
   ReleaseVersion = 'release-version',
 }
 
 export interface ActionInputs {
-  readonly IsInitialRelease: boolean;
   readonly ReleaseType: AcceptedSemverReleaseTypes | null;
   readonly ReleaseVersion: string | null;
 }
@@ -62,7 +58,6 @@ const TWO_SPACES = '  ';
  */
 export function getActionInputs(): ActionInputs {
   const inputs: ActionInputs = {
-    IsInitialRelease: process.env[InputKeys.IsInitialRelease] === 'true',
     ReleaseType:
       (process.env[InputKeys.ReleaseType] as AcceptedSemverReleaseTypes) ||
       null,
@@ -77,15 +72,6 @@ export function getActionInputs(): ActionInputs {
  * Throws an error if validation fails.
  */
 function validateActionInputs(inputs: ActionInputs): void {
-  if (
-    process.env.IS_INITIAL_RELEASE !== 'true' &&
-    process.env.IS_INITIAL_RELEASE !== 'false'
-  ) {
-    throw new Error(
-      `"${InputNames.IsInitialRelease}" must be either "true" or "false".`,
-    );
-  }
-
   if (!inputs.ReleaseType && !inputs.ReleaseVersion) {
     throw new Error(
       `Must specify either "${InputNames.ReleaseType}" or "${InputNames.ReleaseVersion}".`,


### PR DESCRIPTION
Previously, this action would always fail if `git tag` returned no tags. With this PR, the action will only fail in that case if the local git history is incomplete. If the local git history is complete, we assume that it's the initial release, and update every package.

Also fixes a couple of incidental string-related bugs in `git-operations.ts`, and adds a missing `eslint` flag in a lint script.

Closes #5 