### PR TITLE
Document how to create a hotfix release

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,4 +40,7 @@ jobs:
             - uses: MetaMask/action-monorepo-release-pr@0.0.1
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              with:
+                  release-type: ${{ github.event.inputs.release-type }}
+                  release-version: ${{ github.event.inputs.release-version }}
 ```

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ name: Create Monorepo Release Pull Request
 on:
     workflow_dispatch:
         inputs:
+            base-branch:
+                description: 'The base branch for git operations and the pull request.'
+                default: 'main'
+                required: true
             release-type:
                 description: 'A SemVer version diff, i.e. major, minor, patch, prerelease etc. Mutually exclusive with "release-version".'
                 required: false
@@ -24,6 +28,9 @@ jobs:
                   # This is to guarantee that the most recent tag is fetched.
                   # This can be configured to a more reasonable value by consumers.
                   fetch-depth: 0
+                  # We check out the specified branch, which will be used as the base
+                  # branch for all git operations and the release PR.
+                  ref: ${{ inputs.base-branch }}
             - name: Get Node.js version
               id: nvm
               run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)


### PR DESCRIPTION
As it turns out, the power to create a hotfix release was [inside us all along](https://github.com/actions/checkout#Checkout-a-different-branch). This PR documents how to do it in the readme.

Closes #13 