### PR TITLE
Update git-operations and tests

### DIFF
--- a/src/git-operations.test.ts
+++ b/src/git-operations.test.ts
@@ -19,7 +19,9 @@ enum TAGS {
   C = 'v1.1.0',
 }
 
-const PACKAGES: Readonly<Record<string, { name: string; dir: string }>> = {
+type MockPackage = Readonly<{ name: string; dir: string }>;
+
+const PACKAGES: Readonly<Record<string, MockPackage>> = {
   A: { name: 'fooName', dir: 'foo' },
   B: { name: 'barName', dir: 'bar' },
 };

--- a/src/git-operations.test.ts
+++ b/src/git-operations.test.ts
@@ -26,7 +26,7 @@ const PACKAGES: Readonly<Record<string, { name: string; dir: string }>> = {
 
 const RAW_MOCK_TAGS = `${Object.values(TAGS).join('\n')}\n`;
 
-const DEFAULT_TAGS: Readonly<Set<string>> = new Set(Object.values(TAGS));
+const PARSED_MOCK_TAGS: ReadonlySet<string> = new Set(Object.values(TAGS));
 
 const RAW_DIFFS: Readonly<Record<TAGS, string>> = {
   [TAGS.A]: `packages/${PACKAGES.A.dir}/file.txt\npackages/${PACKAGES.B.dir}/file.txt\n`,
@@ -41,7 +41,7 @@ describe('getTags', () => {
       return { stdout: RAW_MOCK_TAGS };
     });
 
-    expect(await getTags()).toStrictEqual([DEFAULT_TAGS, TAGS.C]);
+    expect(await getTags()).toStrictEqual([PARSED_MOCK_TAGS, TAGS.C]);
     expect(execaMock).toHaveBeenCalledTimes(1);
   });
 
@@ -117,7 +117,7 @@ describe('didPackageChange', () => {
     });
 
     expect(
-      await didPackageChange(DEFAULT_TAGS, {
+      await didPackageChange(PARSED_MOCK_TAGS, {
         name: PACKAGES.A.name,
         manifest: { name: PACKAGES.A.name, version: VERSIONS.A },
         dirName: PACKAGES.A.dir,
@@ -129,7 +129,7 @@ describe('didPackageChange', () => {
 
   it('repeat call for tag retrieves result from cache', async () => {
     expect(
-      await didPackageChange(DEFAULT_TAGS, {
+      await didPackageChange(PARSED_MOCK_TAGS, {
         name: PACKAGES.A.name,
         manifest: { name: PACKAGES.A.name, version: VERSIONS.A },
         dirName: PACKAGES.A.dir,
@@ -141,7 +141,7 @@ describe('didPackageChange', () => {
 
   it('retrieves cached diff on repeat call for tag', async () => {
     expect(
-      await didPackageChange(DEFAULT_TAGS, {
+      await didPackageChange(PARSED_MOCK_TAGS, {
         name: PACKAGES.A.name,
         manifest: { name: PACKAGES.A.name, version: VERSIONS.A },
         dirName: PACKAGES.A.dir,
@@ -153,7 +153,7 @@ describe('didPackageChange', () => {
 
   it('throws if package manifest specifies version without tag', async () => {
     await expect(
-      didPackageChange(DEFAULT_TAGS, {
+      didPackageChange(PARSED_MOCK_TAGS, {
         name: PACKAGES.A.name,
         manifest: { name: PACKAGES.A.name, version: '2.0.0' },
         dirName: PACKAGES.A.dir,

--- a/src/git-operations.ts
+++ b/src/git-operations.ts
@@ -18,7 +18,7 @@ const DIFFS: DiffMap = new Map();
  * The tuple is populated by an empty array and null if there are no tags.
  */
 export async function getTags(): Promise<
-  Readonly<[Set<string>, string | null]>
+  Readonly<[ReadonlySet<string>, string | null]>
 > {
   // The --merged flag ensures that we only get tags that are parents of or
   // equal to the current HEAD.
@@ -87,7 +87,7 @@ async function hasCompleteGitHistory(): Promise<boolean> {
  * returned if there are no releases in the repository's history.
  */
 export async function didPackageChange(
-  tags: Readonly<Set<string>>,
+  tags: ReadonlySet<string>,
   packageData: PackageMetadata,
   packagesDir = 'packages',
 ): Promise<boolean> {

--- a/src/git-operations.ts
+++ b/src/git-operations.ts
@@ -7,124 +7,9 @@ import { isValidSemver, WORKSPACE_ROOT } from './utils';
 const HEAD = 'HEAD';
 
 type DiffMap = Map<string, string[]>;
-
-let INITIALIZED_GIT = false;
-let TAGS: Readonly<Set<string>>;
 const DIFFS: DiffMap = new Map();
 
 /**
- * ATTN: This function must be called before other git operations are performed.
- *
- * Executes "git tag" and caches the result. Throws an error if fetching tags
- * fails.
- *
- * Idempotent, but only if executed serially.
- */
-export async function initializeGit(): Promise<void> {
-  if (!INITIALIZED_GIT) {
-    [TAGS] = await getTags();
-    // eslint-disable-next-line require-atomic-updates
-    INITIALIZED_GIT = true;
-  }
-}
-
-/**
- * ATTN: Only execute serially. Not safely parallelizable.
- *
- * Using git, checks whether the package changed since it was last released.
- *
- * Assumes that initializeGit has been called. If it's not the
- * first release of the package, also assumes that:
- *
- * - The "version" field of the package's manifest corresponds to its latest
- * released version.
- * - The release commit of the package's most recent version is tagged with
- * "v<VERSION>", where <VERSION> is equal to the manifest's "version" field.
- *
- * @param packageData - The metadata of the package to diff.
- * @param packagesDir - The directory containing the monorepo's packages.
- * @returns Whether the package changed since its last release. `true` is
- * returned if there are no releases in the repository's history.
- */
-export async function didPackageChange(
-  packageData: PackageMetadata,
-  packagesDir = 'packages',
-  _tags: never = TAGS as never, // for testing purposes
-): Promise<boolean> {
-  const tags = _tags as typeof TAGS;
-  // In this case, we assume that it's the first release, and every package
-  // is implicitly considered to have "changed".
-  if (tags.size === 0) {
-    return true;
-  }
-
-  const {
-    manifest: { name: packageName, version: currentVersion },
-  } = packageData;
-  const tagOfCurrentVersion = versionToTag(currentVersion);
-
-  if (!tags.has(tagOfCurrentVersion)) {
-    throw new Error(
-      `Package "${packageName}" has version "${currentVersion}" in its manifest, but no corresponding tag "${tagOfCurrentVersion}" exists.`,
-    );
-  }
-  return hasDiff(packageData, tagOfCurrentVersion, packagesDir);
-}
-
-/**
- * Retrieves the diff for the given tag from the cache or performs the git diff
- * operation, caching the result and returning it.
- *
- * @param packageData - The metadata of the package to diff.
- * @param tag - The tag corresponding to the package's latest release.
- * @param packagesDir - The monorepo's packages directory.
- * @returns Whether the package changed since its last release.
- */
-async function hasDiff(
-  packageData: PackageMetadata,
-  tag: string,
-  packagesDir: string,
-): Promise<boolean> {
-  const { dirName: packageDirName } = packageData;
-
-  let diff: string[];
-  if (DIFFS.has(tag)) {
-    diff = DIFFS.get(tag) as string[];
-  } else {
-    diff = await performDiff(tag, packagesDir);
-    DIFFS.set(tag, diff);
-  }
-
-  const packagePathPrefix = pathUtils.join(packagesDir, packageDirName);
-  return diff.some((diffPath) => diffPath.startsWith(packagePathPrefix));
-}
-
-/**
- * Wrapper function for executing "git diff".
- *
- * @param tag - The tag to compare against HEAD.
- * @param packagesDir - The monorepo's packages directory. Used for narrowing
- * git diff results.
- */
-async function performDiff(
-  tag: string,
-  packagesDir: string,
-): Promise<string[]> {
-  return (
-    await performGitOperation(
-      'diff',
-      tag,
-      HEAD,
-      '--name-only',
-      '--',
-      packagesDir,
-    )
-  ).split('\n');
-}
-
-/**
- * ATTN: Only exported for testing purposes. Consumers should use initializeGit.
- *
  * Utility function for executing "git tag" and parsing the result.
  * An error is thrown if no tags are found and the local git history is
  * incomplete.
@@ -181,6 +66,99 @@ async function hasCompleteGitHistory(): Promise<boolean> {
   throw new Error(
     `"git rev-parse --is-shallow-repository" returned unrecognized value: ${isShallow}`,
   );
+}
+
+/**
+ * ATTN: Only execute serially. Not safely parallelizable.
+ *
+ * Using git, checks whether the package changed since it was last released.
+ *
+ * Unless it's the first release of the package, assumes that:
+ *
+ * - The "version" field of the package's manifest corresponds to its latest
+ * released version.
+ * - The release commit of the package's most recent version is tagged with
+ * "v<VERSION>", where <VERSION> is equal to the manifest's "version" field.
+ *
+ * @param tags - All tags for the release's base git branch.
+ * @param packageData - The metadata of the package to diff.
+ * @param packagesDir - The directory containing the monorepo's packages.
+ * @returns Whether the package changed since its last release. `true` is
+ * returned if there are no releases in the repository's history.
+ */
+export async function didPackageChange(
+  tags: Readonly<Set<string>>,
+  packageData: PackageMetadata,
+  packagesDir = 'packages',
+): Promise<boolean> {
+  // In this case, we assume that it's the first release, and every package
+  // is implicitly considered to have "changed".
+  if (tags.size === 0) {
+    return true;
+  }
+
+  const {
+    manifest: { name: packageName, version: currentVersion },
+  } = packageData;
+  const tagOfCurrentVersion = versionToTag(currentVersion);
+
+  if (!tags.has(tagOfCurrentVersion)) {
+    throw new Error(
+      `Package "${packageName}" has version "${currentVersion}" in its manifest, but no corresponding tag "${tagOfCurrentVersion}" exists.`,
+    );
+  }
+  return hasDiff(packageData, tagOfCurrentVersion, packagesDir);
+}
+
+/**
+ * Retrieves the diff for the given tag from the cache or performs the git diff
+ * operation, caching the result and returning it.
+ *
+ * @param packageData - The metadata of the package to diff.
+ * @param tag - The tag corresponding to the package's latest release.
+ * @param packagesDir - The monorepo's packages directory.
+ * @returns Whether the package changed since its last release.
+ */
+async function hasDiff(
+  packageData: PackageMetadata,
+  tag: string,
+  packagesDir: string,
+): Promise<boolean> {
+  const { dirName: packageDirName } = packageData;
+
+  let diff: string[];
+  if (DIFFS.has(tag)) {
+    diff = DIFFS.get(tag) as string[];
+  } else {
+    diff = await getDiff(tag, packagesDir);
+    DIFFS.set(tag, diff);
+  }
+
+  const packagePathPrefix = pathUtils.join(packagesDir, packageDirName);
+  return diff.some((diffPath) => diffPath.startsWith(packagePathPrefix));
+}
+
+/**
+ * Wrapper function for diffing packages between a particular tag and the
+ * current HEAD.
+ *
+ * @param tag - The tag to compare against HEAD.
+ * @param packagesDir - The monorepo's packages directory. Used for narrowing
+ * git diff results.
+ * @returns An array of paths to files in the packages directory that were
+ * changed between the tag and the current HEAD.
+ */
+async function getDiff(tag: string, packagesDir: string): Promise<string[]> {
+  return (
+    await performGitOperation(
+      'diff',
+      tag,
+      HEAD,
+      '--name-only',
+      '--',
+      packagesDir,
+    )
+  ).split('\n');
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ import {
   getPackageManifest,
   updatePackage,
 } from './package-operations';
-import { initializeGit } from './git-operations';
+import { getTags } from './git-operations';
 import { getActionInputs, isMajorSemverDiff, WORKSPACE_ROOT } from './utils';
 
 main().catch((error) => {
@@ -25,7 +25,7 @@ async function main(): Promise<void> {
 
   // Get all git tags. An error is thrown if "git tag" returns no tags and the
   // local git history is incomplete.
-  await initializeGit();
+  const [tags] = await getTags();
 
   const rootManifest = await getPackageManifest(WORKSPACE_ROOT, ['version']);
   const { version: currentVersion } = rootManifest;
@@ -53,6 +53,7 @@ async function main(): Promise<void> {
   const packagesToUpdate = await getPackagesToUpdate(
     allPackages,
     synchronizeVersions,
+    tags,
   );
   const updateSpecification = {
     newVersion,

--- a/src/package-operations.test.ts
+++ b/src/package-operations.test.ts
@@ -197,7 +197,7 @@ describe('package-operations', () => {
 
     it('returns all packages if synchronizeVersions is true', async () => {
       expect(
-        await getPackagesToUpdate(mockMetadataRecord as any, true),
+        await getPackagesToUpdate(mockMetadataRecord as any, true, new Set()),
       ).toStrictEqual(new Set(packageNames));
       expect(didPackageChangeMock).not.toHaveBeenCalled();
     });
@@ -209,7 +209,7 @@ describe('package-operations', () => {
         .mockImplementationOnce(async () => false);
 
       expect(
-        await getPackagesToUpdate(mockMetadataRecord as any, false),
+        await getPackagesToUpdate(mockMetadataRecord as any, false, new Set()),
       ).toStrictEqual(new Set([packageNames[1]]));
       expect(didPackageChangeMock).toHaveBeenCalledTimes(3);
     });
@@ -218,7 +218,7 @@ describe('package-operations', () => {
       didPackageChangeMock.mockImplementation(async () => false);
 
       await expect(
-        getPackagesToUpdate(mockMetadataRecord as any, false),
+        getPackagesToUpdate(mockMetadataRecord as any, false, new Set()),
       ).rejects.toThrow(/no packages to update/u);
       expect(didPackageChangeMock).toHaveBeenCalledTimes(3);
     });

--- a/src/package-operations.ts
+++ b/src/package-operations.ts
@@ -78,11 +78,13 @@ export async function getMetadataForAllPackages(
  * @param allPackages - The metadata of all packages in the monorepo.
  * @param synchronizeVersions - Whether to synchronize the versions of all
  * packages.
+ * @param tags - All tags for the release's base git branch.
  * @returns The names of the packages to update.
  */
 export async function getPackagesToUpdate(
   allPackages: Record<string, PackageMetadata>,
   synchronizeVersions: boolean,
+  tags: Readonly<Set<string>>,
 ): Promise<Set<string>> {
   // In order to synchronize versions, we must update every package.
   if (synchronizeVersions) {
@@ -94,7 +96,7 @@ export async function getPackagesToUpdate(
   // We use a for-loop here instead of Promise.all because didPackageChange
   // must be called serially.
   for (const packageName of Object.keys(allPackages)) {
-    if (await didPackageChange(allPackages[packageName])) {
+    if (await didPackageChange(tags, allPackages[packageName])) {
       shouldBeUpdated.add(packageName);
     }
   }

--- a/src/package-operations.ts
+++ b/src/package-operations.ts
@@ -84,7 +84,7 @@ export async function getMetadataForAllPackages(
 export async function getPackagesToUpdate(
   allPackages: Record<string, PackageMetadata>,
   synchronizeVersions: boolean,
-  tags: Readonly<Set<string>>,
+  tags: ReadonlySet<string>,
 ): Promise<Set<string>> {
   // In order to synchronize versions, we must update every package.
   if (synchronizeVersions) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -59,12 +59,24 @@ const TWO_SPACES = '  ';
 export function getActionInputs(): ActionInputs {
   const inputs: ActionInputs = {
     ReleaseType:
-      (process.env[InputKeys.ReleaseType] as AcceptedSemverReleaseTypes) ||
-      null,
-    ReleaseVersion: process.env[InputKeys.ReleaseVersion] || null,
+      (getProcessEnvValue(
+        InputKeys.ReleaseType,
+      ) as AcceptedSemverReleaseTypes) || null,
+    ReleaseVersion: getProcessEnvValue(InputKeys.ReleaseVersion) || null,
   };
   validateActionInputs(inputs);
   return inputs;
+}
+
+/**
+ * Utility function to get the trimmed value of a particular key of process.env.
+ *
+ * @param key - The key of process.env to access.
+ * @returns The trimmed string value of the process.env key. Returns an empty
+ * string if the key is not set.
+ */
+function getProcessEnvValue(key: string): string {
+  return process.env[key]?.trim() || '';
 }
 
 /**


### PR DESCRIPTION
Following feedback in #16, this PR updates `git-operations.ts` and its tests. Specifically, the tags are no longer cached at the module-level, and are simply retrieved once in the main entry file and thereafter passed to the function that needs them. `initializeGit` is removed completely.