### PR TITLE
Re-enable 'no-unpublished' ESLint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,8 +6,6 @@ module.exports = {
   rules: {
     'node/no-process-env': 'off',
     'node/no-sync': 'off',
-    'node/no-unpublished-import': 'off',
-    'node/no-unpublished-require': 'off',
   },
 
   overrides: [

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "action-monorepo-release-pr",
   "version": "0.0.1",
   "description": "A GitHub Action for creating a monorepo release PR.",
+  "files": [
+    "lib/"
+  ],
   "main": "lib/index.js",
   "engines": {
     "node": ">=12.10.0",


### PR DESCRIPTION
These rules prevent accidentally forgetting to list production dependencies. They have been re-enabled. The only violation was caused by an import in a test, which was being flagged because all modules were considered as part of the final published package. There was no `.npmignore` file or `files` property in `package.json` to declare which files are published, so all files were assumed to be published.

The `files` property has been added, so test files are no longer considered by these rules.