### PR TITLE
Enable the `node/no-sync` ESLint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,7 +5,6 @@ module.exports = {
 
   rules: {
     'node/no-process-env': 'off',
-    'node/no-sync': 'off',
     'node/no-unpublished-import': 'off',
     'node/no-unpublished-require': 'off',
   },


### PR DESCRIPTION
This rule prevents the use of synchronous core library methods. There were no violations.