### PR TITLE
Fix package manifest validation and typing

### DIFF
--- a/src/update.test.ts
+++ b/src/update.test.ts
@@ -43,6 +43,7 @@ describe('performUpdate', () => {
 
   let getRepositoryHttpsUrlMock: jest.SpyInstance;
   let getTagsMock: jest.SpyInstance;
+  let consoleLogMock: jest.SpyInstance;
   let getPackageManifestMock: jest.SpyInstance;
   let setActionOutputMock: jest.SpyInstance;
 
@@ -56,6 +57,9 @@ describe('performUpdate', () => {
         new Set(['1.0.0', '1.1.0']),
         '1.1.0',
       ]);
+    consoleLogMock = jest
+      .spyOn(console, 'log')
+      .mockImplementation(() => undefined);
     getPackageManifestMock = jest.spyOn(
       packageOperations,
       'getPackageManifest',
@@ -78,6 +82,10 @@ describe('performUpdate', () => {
     await performUpdate({ ReleaseType: null, ReleaseVersion: newVersion });
     expect(getRepositoryHttpsUrlMock).toHaveBeenCalledTimes(1);
     expect(getTagsMock).toHaveBeenCalledTimes(1);
+    expect(consoleLogMock).toHaveBeenCalledTimes(1);
+    expect(consoleLogMock).toHaveBeenCalledWith(
+      expect.stringMatching(/Applying polyrepo workflow/u),
+    );
     expect(packageOperations.updatePackage).toHaveBeenCalledTimes(1);
     expect(packageOperations.updatePackage).toHaveBeenCalledWith(
       {
@@ -108,6 +116,10 @@ describe('performUpdate', () => {
     });
     expect(getRepositoryHttpsUrlMock).toHaveBeenCalledTimes(1);
     expect(getTagsMock).toHaveBeenCalledTimes(1);
+    expect(consoleLogMock).toHaveBeenCalledTimes(1);
+    expect(consoleLogMock).toHaveBeenCalledWith(
+      expect.stringMatching(/Applying polyrepo workflow/u),
+    );
     expect(packageOperations.updatePackage).toHaveBeenCalledTimes(1);
     expect(packageOperations.updatePackage).toHaveBeenCalledWith(
       {
@@ -149,6 +161,10 @@ describe('performUpdate', () => {
 
     expect(getRepositoryHttpsUrlMock).toHaveBeenCalledTimes(1);
     expect(getTagsMock).toHaveBeenCalledTimes(1);
+    expect(consoleLogMock).toHaveBeenCalledTimes(1);
+    expect(consoleLogMock).toHaveBeenCalledWith(
+      expect.stringMatching(/Applying monorepo workflow/u),
+    );
     expect(getPackagesMetadataMock).toHaveBeenCalledTimes(1);
 
     expect(getPackagesToUpdateMock).toHaveBeenCalledTimes(1);

--- a/src/update.ts
+++ b/src/update.ts
@@ -9,13 +9,13 @@ import {
   getMetadataForAllPackages,
   getPackagesToUpdate,
   getPackageManifest,
-  PackageManifest,
   updatePackage,
   updatePackages,
-  MonorepoPackageManifest,
   validateMonorepoPackageManifest,
   validatePackageManifestVersion,
   validatePackageManifestName,
+  MonorepoPackageManifest,
+  PolyrepoPackageManifest,
 } from './package-operations';
 import { ActionInputs, isMajorSemverDiff, WORKSPACE_ROOT } from './utils';
 
@@ -91,7 +91,7 @@ export async function performUpdate(actionInputs: ActionInputs): Promise<void> {
  */
 async function updatePolyrepo(
   newVersion: string,
-  manifest: PackageManifest,
+  manifest: PolyrepoPackageManifest,
   repositoryUrl: string,
 ): Promise<void> {
   await updatePackage(
@@ -118,10 +118,7 @@ async function updatePolyrepo(
 async function updateMonorepo(
   newVersion: string,
   versionDiff: SemverReleaseType,
-  rootManifest: Pick<
-    MonorepoPackageManifest,
-    FieldNames.Version | FieldNames.Workspaces
-  >,
+  rootManifest: MonorepoPackageManifest,
   repositoryUrl: string,
   tags: ReadonlySet<string>,
 ): Promise<void> {

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -6,7 +6,7 @@ import {
   isMajorSemverDiff,
   isTruthyString,
   isValidSemver,
-  readJsonFile,
+  readJsonObjectFile,
   writeJsonFile,
   tabs,
 } from './utils';
@@ -90,7 +90,7 @@ describe('getActionInputs', () => {
   });
 });
 
-describe('readJsonFile', () => {
+describe('readJsonObjectFile', () => {
   it('reads a JSON file and returns it as an object', async () => {
     const expectedResult = { foo: ['bar', 'baz'] };
     const path = 'arbitrary/path';
@@ -100,7 +100,7 @@ describe('readJsonFile', () => {
       .spyOn(fs.promises, 'readFile')
       .mockImplementationOnce(async () => mockJsonString);
 
-    const result = await readJsonFile(path);
+    const result = await readJsonObjectFile(path);
     expect(result).toStrictEqual(expectedResult);
   });
 
@@ -113,18 +113,25 @@ describe('readJsonFile', () => {
       .spyOn(fs.promises, 'readFile')
       .mockImplementationOnce(async () => mockJsonString);
 
-    await expect(readJsonFile(path)).rejects.toThrow(/^Unexpected token/u);
+    await expect(readJsonObjectFile(path)).rejects.toThrow(
+      /^Unexpected token/u,
+    );
   });
 
   it('throws an error if the file parses to a falsy value', async () => {
     const path = 'arbitrary/path';
-    const mockJsonString = 'null';
 
     jest
       .spyOn(fs.promises, 'readFile')
-      .mockImplementationOnce(async () => mockJsonString);
+      .mockImplementationOnce(async () => 'null')
+      .mockImplementationOnce(async () => '[]')
+      .mockImplementationOnce(async () => 'foobar')
+      .mockImplementationOnce(async () => 'true')
+      .mockImplementationOnce(async () => 'false');
 
-    await expect(readJsonFile(path)).rejects.toThrow(/falsy value\.$/u);
+    await expect(readJsonObjectFile(path)).rejects.toThrow(
+      /non-object value\.$/u,
+    );
   });
 });
 

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -118,7 +118,7 @@ describe('readJsonObjectFile', () => {
     );
   });
 
-  it('throws an error if the file parses to a falsy value', async () => {
+  it('throws an error if the file parses to a non-object value', async () => {
     const path = 'arbitrary/path';
     const readFileMock = jest.spyOn(fs.promises, 'readFile');
     const badJsonValues = ['null', '[]', '"foobar"', 'true', 'false', '2'];

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -120,18 +120,15 @@ describe('readJsonObjectFile', () => {
 
   it('throws an error if the file parses to a falsy value', async () => {
     const path = 'arbitrary/path';
+    const readFileMock = jest.spyOn(fs.promises, 'readFile');
+    const badJsonValues = ['null', '[]', '"foobar"', 'true', 'false', '2'];
 
-    jest
-      .spyOn(fs.promises, 'readFile')
-      .mockImplementationOnce(async () => 'null')
-      .mockImplementationOnce(async () => '[]')
-      .mockImplementationOnce(async () => 'foobar')
-      .mockImplementationOnce(async () => 'true')
-      .mockImplementationOnce(async () => 'false');
-
-    await expect(readJsonObjectFile(path)).rejects.toThrow(
-      /non-object value\.$/u,
-    );
+    for (const badValue of badJsonValues) {
+      readFileMock.mockImplementationOnce(async () => badValue);
+      await expect(readJsonObjectFile(path)).rejects.toThrow(
+        /non-object value\.$/u,
+      );
+    }
   });
 });
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -123,13 +123,14 @@ function validateActionInputs(inputs: ActionInputs): void {
  * Reads the assumed JSON file at the given path, attempts to parse it, and
  * returns the resulting object.
  *
- * Throws if failing to read or parse, or if the parsed JSON value is falsy.
+ * Throws if failing to read or parse, or if the parsed JSON value is not a
+ * plain object.
  *
  * @param paths - The path segments pointing to the JSON file. Will be passed
  * to path.join().
  * @returns The object corresponding to the parsed JSON file.
  */
-export async function readJsonFile(
+export async function readJsonObjectFile(
   path: string,
 ): Promise<Record<string, unknown>> {
   const obj = JSON.parse(await fs.readFile(path, 'utf8')) as Record<
@@ -137,9 +138,9 @@ export async function readJsonFile(
     unknown
   >;
 
-  if (!obj) {
+  if (!obj || typeof obj !== 'object' || Array.isArray(obj)) {
     throw new Error(
-      `Assumed JSON file at path "${path}" parsed to a falsy value.`,
+      `Assumed JSON file at path "${path}" parsed to a non-object value.`,
     );
   }
   return obj;


### PR DESCRIPTION
This PR improves the validation and type checking of package manifest objects. Previously, we were casting package manifest objects and using `Partial` needlessly. Now, the `validatePackageManifest` function acts as a type guard by returning the unmodified package manifest object, but with correct types.

As part of this improved validation, `readJsonFile` has been renamed to `readJsonObjectFile` and rewritten to error if the parsed JSON is anything other than a plain object, as opposed to just a falsy value.